### PR TITLE
Update chatbot_app.py

### DIFF
--- a/chatbot_app.py
+++ b/chatbot_app.py
@@ -40,6 +40,8 @@ with (st.sidebar):
             text = docx2txt.process(uploaded_file)
         elif file_type in ['image/jpg', 'image/jpeg', 'image/png']:
             image = Image.open(uploaded_file)
+            image = image.convert('RGB')
+            
             st.image(image, caption="Uploaded Image", use_column_width=True)
             buffered = BytesIO()
             image.save(buffered, format="JPEG")
@@ -257,5 +259,3 @@ else:
         msg = ans
         st.session_state.messages.append({"role": "assistant", "content": msg})
         st.chat_message("assistant").write(msg)
-
-


### PR DESCRIPTION
address an issue when handling PNG images with transparency channels. When converting such images to JPEG format (which doesn't support transparency), the resulting image would have artifacts or errors due to the transparency channel.

image = Image.open(uploaded_file)
image = image.convert('RGB')